### PR TITLE
Fix: Adjust SafeAreaView for consistent header spacing

### DIFF
--- a/app/(tabs)/challenges.tsx
+++ b/app/(tabs)/challenges.tsx
@@ -138,7 +138,7 @@ export default function ChallengesScreen() {
   // Show loading indicator while fetching data
   if (isLoading) {
     return (
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView style={styles.container} edges={['right', 'left']}>
         <StatusBar style="auto" />
         {/* Header is now managed by navigation options */}
         <View style={styles.loadingContainer}>
@@ -152,7 +152,7 @@ export default function ChallengesScreen() {
   // Show error if there's an issue fetching data
   if (error) {
     return (
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView style={styles.container} edges={['right', 'left']}>
         <StatusBar style="auto" />
         {/* Header is now managed by navigation options */}
         <View style={styles.errorContainer}>
@@ -167,7 +167,7 @@ export default function ChallengesScreen() {
   }
 
   return (
-    <SafeAreaView style={styles.container}>
+    <SafeAreaView style={styles.container} edges={['right', 'left']}>
       <StatusBar style="auto" />
       {/* Header is now managed by navigation options, remove local header */}
       {/* Categories */}

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -816,7 +816,7 @@ export default function ProfileScreen() {
 
   if (!user || loading) {
     return (
-      <SafeAreaView style={styles.loadingContainer}>
+      <SafeAreaView style={styles.loadingContainer} edges={['right', 'left']}>
         <ActivityIndicator size="large" color={THEME.COLORS.primary} />
       </SafeAreaView>
     );
@@ -824,7 +824,7 @@ export default function ProfileScreen() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <SafeAreaView style={styles.container}>
+      <SafeAreaView style={styles.container} edges={['right', 'left']}>
         <StatusBar style="auto" />
 
         <View style={styles.header}>
@@ -920,6 +920,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 15,
     paddingVertical: 12,
     backgroundColor: THEME.COLORS.card,
+    paddingTop: 10,
   },
   userInfoContainer: {
     flexDirection: 'row',


### PR DESCRIPTION
Corrected spacing issues in the Profile and Challenges tabs by modifying SafeAreaView configurations.

- Changed SafeAreaView instances in `app/(tabs)/profile.tsx` and `app/(tabs)/challenges.tsx` to use `edges={['right', 'left']}`.
- This prevents double padding when used with the native header provided by Expo Router.
- Added `paddingTop` to the custom header in `profile.tsx` to maintain its layout, similar to the reference Home screen (`index.tsx`).

These changes aim to ensure consistent header and content spacing across tabs, using the Home screen's implementation as a reference.